### PR TITLE
Add support for labels and running them

### DIFF
--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -9,6 +9,7 @@ pub enum InstructionSet {
     DIV,
     RET,
     MOD,
+    LOADLABEL,
 }
 
 impl PartialEq for InstructionSet {
@@ -21,6 +22,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::DIV, InstructionSet::DIV) => true,
             (InstructionSet::RET, InstructionSet::RET) => true,
             (InstructionSet::MOD, InstructionSet::MOD) => true,
+            (InstructionSet::LOADLABEL, InstructionSet::LOADLABEL) => true,
             _ => false,
         }
     }
@@ -41,6 +43,7 @@ impl InstructionSet {
             4 => InstructionSet::DIV,
             5 => InstructionSet::RET,
             6 => InstructionSet::MOD,
+            7 => InstructionSet::LOADLABEL,
             _ => panic!("Invalid instruction set value: {}", value),
         }
     }

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -89,6 +89,7 @@ impl Processor {
 
                 stack.push(a % b);
             }
+            InstructionSet::LOADLABEL => {},
         }
     }
 

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -22,6 +22,9 @@ fn test_instruction_equality() {
 
     let instruction = InstructionSet::MOD;
     assert_eq!(instruction, InstructionSet::MOD);
+
+    let instruction = InstructionSet::LOADLABEL;
+    assert_eq!(instruction, InstructionSet::LOADLABEL);
 }
 
 #[test]
@@ -46,4 +49,7 @@ fn test_instruction_from_int() {
 
     let instruction = InstructionSet::from_int(6, None);
     assert_eq!(instruction, InstructionSet::MOD);
+
+    let instruction = InstructionSet::from_int(7, None);
+    assert_eq!(instruction, InstructionSet::LOADLABEL);
 }

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -103,6 +103,17 @@ fn test_execute_mod() {
 }
 
 #[test]
+fn test_execute_loadlable() {
+    let mut stack = Stack::new();
+    let processor = Processor::new();
+
+    processor.execute(&InstructionSet::LOADLABEL, &mut stack, &mut Vec::new());
+
+    assert_eq!(stack.data(), &[]);
+    assert_eq!(stack.head(), 0);
+}
+
+#[test]
 fn test_execute_program() {
     let mut program = Vec::new();
 


### PR DESCRIPTION
Closes #5 

**Implementation**

1. Identify LOADLAEL instruction in the instruction set.
2. In the processor skip the instruction as LOADLABEL does not require any execution.