### PR TITLE
Add JMP implementation

### DIFF
--- a/src/binread/bin_read.rs
+++ b/src/binread/bin_read.rs
@@ -24,21 +24,28 @@ pub fn read_from_file(filepath: &str) -> Vec<InstructionSet> {
         Err(e) => println!("Error: {}", e),
     }
 
+    let instruction_with_arg = vec![
+        0, // LOAD
+        8, // JMP
+    ];
+
     let mut program = Vec::new();
     let mut is_reading_arg = false;
+    let mut current_arg_instruction = 0;
     let mut arg: InnerData;
 
     for byte in buffer {
         if is_reading_arg {
             arg = byte as InnerData;
-            let instruction = InstructionSet::from_int(0, Some(arg));
+            let instruction = InstructionSet::from_int(current_arg_instruction, Some(arg));
             program.push(instruction);
             is_reading_arg = false;
             continue;
         }
 
-        if byte as InnerData == 0 {
+        if instruction_with_arg.contains(&byte) {
             is_reading_arg = true;
+            current_arg_instruction = byte;
         } else {
             let instruction = InstructionSet::from_int(byte as u8, None);
             program.push(instruction);

--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -10,6 +10,7 @@ pub enum InstructionSet {
     RET,
     MOD,
     LOADLABEL,
+    JMP(InnerData),
 }
 
 impl PartialEq for InstructionSet {
@@ -23,6 +24,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::RET, InstructionSet::RET) => true,
             (InstructionSet::MOD, InstructionSet::MOD) => true,
             (InstructionSet::LOADLABEL, InstructionSet::LOADLABEL) => true,
+            (InstructionSet::JMP(a), InstructionSet::JMP(b)) => a == b,
             _ => false,
         }
     }
@@ -44,6 +46,12 @@ impl InstructionSet {
             5 => InstructionSet::RET,
             6 => InstructionSet::MOD,
             7 => InstructionSet::LOADLABEL,
+            8 => {
+                match arg {
+                    Some(arg) => InstructionSet::JMP(arg),
+                    None => panic!("InstructionSet::JMP: arg is None"),
+                }
+            },
             _ => panic!("Invalid instruction set value: {}", value),
         }
     }

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -14,7 +14,7 @@ impl Processor {
         }
     }
 
-    pub fn execute(&self, instruction: &InstructionSet, stack: &mut Stack, stdout: &mut dyn io::Write) {
+    pub fn execute(&mut self, instruction: &InstructionSet, stack: &mut Stack, stdout: &mut dyn io::Write) {
         match instruction {
             InstructionSet::LOAD(value) => {
                 stack.push(*value);
@@ -90,6 +90,9 @@ impl Processor {
                 stack.push(a % b);
             }
             InstructionSet::LOADLABEL => {},
+            InstructionSet::JMP(value) => {
+                self.pc = *value as usize;
+            },
         }
     }
 
@@ -97,6 +100,7 @@ impl Processor {
         loop {
             let instruction = memory.get_value(self.pc);
             self.execute(instruction, stack, stdout);
+
             self.pc += 1;
 
             if *instruction == InstructionSet::RET {

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -25,6 +25,9 @@ fn test_instruction_equality() {
 
     let instruction = InstructionSet::LOADLABEL;
     assert_eq!(instruction, InstructionSet::LOADLABEL);
+
+    let instruction = InstructionSet::JMP(3);
+    assert_eq!(instruction, InstructionSet::JMP(3));
 }
 
 #[test]
@@ -52,4 +55,7 @@ fn test_instruction_from_int() {
 
     let instruction = InstructionSet::from_int(7, None);
     assert_eq!(instruction, InstructionSet::LOADLABEL);
+
+    let instruction = InstructionSet::from_int(8, Some(2));
+    assert_eq!(instruction, InstructionSet::JMP(2));
 }

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -7,7 +7,7 @@ use yamini::instructions::InstructionSet;
 fn test_execute_load() {
     let mut stack = Stack::new();
 
-    let processor = Processor::new();
+    let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::LOAD(3), &mut stack, &mut Vec::new());
 
@@ -21,7 +21,7 @@ fn test_execute_add() {
     stack.push(3);
     stack.push(4);
 
-    let processor = Processor::new();
+    let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::ADD, &mut stack, &mut Vec::new());
 
@@ -35,7 +35,7 @@ fn test_execute_sub() {
     stack.push(3);
     stack.push(4);
 
-    let processor = Processor::new();
+    let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::SUB, &mut stack, &mut Vec::new());
 
@@ -49,7 +49,7 @@ fn test_execute_mul() {
     stack.push(3);
     stack.push(4);
 
-    let processor = Processor::new();
+    let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::MUL, &mut stack, &mut Vec::new());
 
@@ -63,7 +63,7 @@ fn test_execute_div() {
     stack.push(12);
     stack.push(4);
 
-    let processor = Processor::new();
+    let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::DIV, &mut stack, &mut Vec::new());
 
@@ -76,7 +76,7 @@ fn test_execute_ret() {
     let mut stack = Stack::new();
     stack.push(3);
 
-    let processor = Processor::new();
+    let mut processor = Processor::new();
 
     let mut stdout = Vec::new();
 
@@ -94,7 +94,7 @@ fn test_execute_mod() {
     stack.push(12);
     stack.push(5);
 
-    let processor = Processor::new();
+    let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::DIV, &mut stack, &mut Vec::new());
 
@@ -103,11 +103,22 @@ fn test_execute_mod() {
 }
 
 #[test]
-fn test_execute_loadlable() {
+fn test_execute_loadlabel() {
     let mut stack = Stack::new();
-    let processor = Processor::new();
+    let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::LOADLABEL, &mut stack, &mut Vec::new());
+
+    assert_eq!(stack.data(), &[]);
+    assert_eq!(stack.head(), 0);
+}
+
+#[test]
+fn test_execute_jmp() {
+    let mut stack = Stack::new();
+    let mut processor = Processor::new();
+
+    processor.execute(&InstructionSet::JMP(2), &mut stack, &mut Vec::new());
 
     assert_eq!(stack.data(), &[]);
     assert_eq!(stack.head(), 0);


### PR DESCRIPTION
Closes #8 

**Implementation**

1. Made binread more generalizable, by allowing to load instructions with arguments other than LOAD instruction.
2. Added JMP to instruction set.
3. Executed JMP by updating the program counter PC to the value specified in the JMP instruction.