### PR TITLE
Add support for LOADREG instruction and 10 GPR

### DIFF
--- a/src/binread/bin_read.rs
+++ b/src/binread/bin_read.rs
@@ -27,6 +27,7 @@ pub fn read_from_file(filepath: &str) -> Vec<InstructionSet> {
     let instruction_with_arg = vec![
         0, // LOAD
         8, // JMP
+        9, // LOADREGISTER
     ];
 
     let mut program = Vec::new();

--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -11,6 +11,7 @@ pub enum InstructionSet {
     MOD,
     LOADLABEL,
     JMP(InnerData),
+    LOADREGISTER(InnerData),
 }
 
 impl PartialEq for InstructionSet {
@@ -25,6 +26,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::MOD, InstructionSet::MOD) => true,
             (InstructionSet::LOADLABEL, InstructionSet::LOADLABEL) => true,
             (InstructionSet::JMP(a), InstructionSet::JMP(b)) => a == b,
+            (InstructionSet::LOADREGISTER(a), InstructionSet::LOADREGISTER(b)) => a == b,
             _ => false,
         }
     }
@@ -50,6 +52,12 @@ impl InstructionSet {
                 match arg {
                     Some(arg) => InstructionSet::JMP(arg),
                     None => panic!("InstructionSet::JMP: arg is None"),
+                }
+            },
+            9 => {
+                match arg {
+                    Some(arg) => InstructionSet::LOADREGISTER(arg),
+                    None => panic!("InstructionSet::LOADREGISTER: arg is None"),
                 }
             },
             _ => panic!("Invalid instruction set value: {}", value),

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -1,16 +1,18 @@
 use std::io;
 use crate::instructions::InstructionSet;
 use crate::memory::stack::Stack;
-use crate::memory::Memory;
+use crate::memory::{Memory, InnerData};
 
 pub struct Processor {
     pc: usize,
+    registers: [InnerData; 10],
 }
 
 impl Processor {
     pub fn new() -> Processor {
         Processor {
             pc: 0,
+            registers: [0; 10],
         }
     }
 
@@ -92,6 +94,13 @@ impl Processor {
             InstructionSet::LOADLABEL => {},
             InstructionSet::JMP(value) => {
                 self.pc = *value as usize;
+            },
+            InstructionSet::LOADREGISTER(register_idx) => {
+                if *register_idx < 0 || (*register_idx as usize) > self.registers.len() {
+                    panic!("Register index out of bounds!");
+                }
+
+                stack.push(self.registers[*register_idx as usize]);
             },
         }
     }

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -28,6 +28,9 @@ fn test_instruction_equality() {
 
     let instruction = InstructionSet::JMP(3);
     assert_eq!(instruction, InstructionSet::JMP(3));
+
+    let instruction = InstructionSet::LOADREGISTER(3);
+    assert_eq!(instruction, InstructionSet::LOADREGISTER(3));
 }
 
 #[test]
@@ -58,4 +61,7 @@ fn test_instruction_from_int() {
 
     let instruction = InstructionSet::from_int(8, Some(2));
     assert_eq!(instruction, InstructionSet::JMP(2));
+
+    let instruction = InstructionSet::from_int(9, Some(2));
+    assert_eq!(instruction, InstructionSet::LOADREGISTER(2));
 }

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -125,6 +125,17 @@ fn test_execute_jmp() {
 }
 
 #[test]
+fn test_execute_loadregister() {
+    let mut stack = Stack::new();
+    let mut processor = Processor::new();
+
+    processor.execute(&InstructionSet::LOADREGISTER(2), &mut stack, &mut Vec::new());
+
+    assert_eq!(stack.data(), &[0]);
+    assert_eq!(stack.head(), 1);
+}
+
+#[test]
 fn test_execute_program() {
     let mut program = Vec::new();
 


### PR DESCRIPTION
Closes #7 

**Implementation**

1. Identify LOADREGISTER instruction in the binary reader and instruction set.
2. Add a vector of size 10 in the processor which holds the value of the 10 registers.
3. Initialize the vector with 0 (zero) during the creation of a new VM instance.
4. While executing LOADREGISTER instruction, check if the register number is valid or not, if it is then push the value of the register to the stack. 