### PR TITLE
Add POPREG instruction support

### DIFF
--- a/src/binread/bin_read.rs
+++ b/src/binread/bin_read.rs
@@ -28,6 +28,7 @@ pub fn read_from_file(filepath: &str) -> Vec<InstructionSet> {
         0, // LOAD
         8, // JMP
         9, // LOADREGISTER
+        10, // POPREGISTER
     ];
 
     let mut program = Vec::new();

--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -12,6 +12,7 @@ pub enum InstructionSet {
     LOADLABEL,
     JMP(InnerData),
     LOADREGISTER(InnerData),
+    POPREGISTER(InnerData),
 }
 
 impl PartialEq for InstructionSet {
@@ -27,6 +28,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::LOADLABEL, InstructionSet::LOADLABEL) => true,
             (InstructionSet::JMP(a), InstructionSet::JMP(b)) => a == b,
             (InstructionSet::LOADREGISTER(a), InstructionSet::LOADREGISTER(b)) => a == b,
+            (InstructionSet::POPREGISTER(a), InstructionSet::POPREGISTER(b)) => a == b,
             _ => false,
         }
     }
@@ -60,6 +62,12 @@ impl InstructionSet {
                     None => panic!("InstructionSet::LOADREGISTER: arg is None"),
                 }
             },
+            10 => {
+                match arg {
+                    Some(arg) => InstructionSet::POPREGISTER(arg),
+                    None => panic!("InstructionSet::POPREGISTER: arg is None"),
+                }
+            }
             _ => panic!("Invalid instruction set value: {}", value),
         }
     }

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -4,6 +4,7 @@ use crate::memory::stack::Stack;
 use crate::memory::{Memory, InnerData};
 
 
+#[allow(dead_code)]
 struct FlagRegister {
     zero: bool,
     negative: bool,
@@ -31,6 +32,7 @@ impl FlagRegister {
 }
 
 
+#[allow(dead_code)]
 pub struct Processor {
     pc: usize,
     registers: [InnerData; 10],
@@ -132,6 +134,16 @@ impl Processor {
 
                 stack.push(self.registers[*register_idx as usize]);
             },
+            InstructionSet::POPREGISTER(register_idx) => {
+                if *register_idx < 0 || (*register_idx as usize) > self.registers.len() {
+                    panic!("Register index out of bounds!");
+                }
+
+                self.registers[*register_idx as usize] = match stack.pop() {
+                    Some(value) => value,
+                    None => panic!("Stack is empty!"),
+                };
+            }
         }
     }
 

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -31,6 +31,9 @@ fn test_instruction_equality() {
 
     let instruction = InstructionSet::LOADREGISTER(3);
     assert_eq!(instruction, InstructionSet::LOADREGISTER(3));
+
+    let instruction = InstructionSet::POPREGISTER(2);
+    assert_eq!(instruction, InstructionSet::POPREGISTER(2));
 }
 
 #[test]
@@ -64,4 +67,7 @@ fn test_instruction_from_int() {
 
     let instruction = InstructionSet::from_int(9, Some(2));
     assert_eq!(instruction, InstructionSet::LOADREGISTER(2));
+
+    let instruction = InstructionSet::from_int(10, Some(2));
+    assert_eq!(instruction, InstructionSet::POPREGISTER(2));
 }

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -136,6 +136,18 @@ fn test_execute_loadregister() {
 }
 
 #[test]
+fn test_execute_popregister() {
+    let mut stack = Stack::new();
+    let mut processor = Processor::new();
+
+    processor.execute(&InstructionSet::LOAD(2), &mut stack, &mut Vec::new());
+    processor.execute(&InstructionSet::POPREGISTER(2), &mut stack, &mut Vec::new());
+
+    assert_eq!(stack.data(), &[]);
+    assert_eq!(stack.head(), 0);
+}
+
+#[test]
 fn test_execute_program() {
     let mut program = Vec::new();
 


### PR DESCRIPTION
Closes #13 

**Implementation**

1. Add POPREG instruction in instruction and identify it in binread.
2. Execute it in processor by popping the value at top of stack and pushing it to the required register if the register index is proper (i.e >= 0 and <= 9).