### PR TITLE
JZ instruction

### DIFF
--- a/src/binread/bin_read.rs
+++ b/src/binread/bin_read.rs
@@ -29,6 +29,7 @@ pub fn read_from_file(filepath: &str) -> Vec<InstructionSet> {
         8, // JMP
         9, // LOADREGISTER
         10, // POPREGISTER
+        11, // JZ
     ];
 
     let mut program = Vec::new();

--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -13,6 +13,7 @@ pub enum InstructionSet {
     JMP(InnerData),
     LOADREGISTER(InnerData),
     POPREGISTER(InnerData),
+    JZ(InnerData),
 }
 
 impl PartialEq for InstructionSet {
@@ -29,6 +30,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::JMP(a), InstructionSet::JMP(b)) => a == b,
             (InstructionSet::LOADREGISTER(a), InstructionSet::LOADREGISTER(b)) => a == b,
             (InstructionSet::POPREGISTER(a), InstructionSet::POPREGISTER(b)) => a == b,
+            (InstructionSet::JZ(a), InstructionSet::JZ(b)) => a == b,
             _ => false,
         }
     }
@@ -67,7 +69,13 @@ impl InstructionSet {
                     Some(arg) => InstructionSet::POPREGISTER(arg),
                     None => panic!("InstructionSet::POPREGISTER: arg is None"),
                 }
-            }
+            },
+            11 => {
+                match arg {
+                    Some(arg) => InstructionSet::JZ(arg),
+                    None => panic!("InstructionSet::JZ: arg is None"),
+                }
+            },
             _ => panic!("Invalid instruction set value: {}", value),
         }
     }

--- a/src/memory/stack.rs
+++ b/src/memory/stack.rs
@@ -35,4 +35,8 @@ impl Stack {
     pub fn head(&self) -> usize {
         self.head
     }
+
+    pub fn top(&self) -> &InnerData {
+        self.data.get(self.head - 1).unwrap()
+    }
 }

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -124,8 +124,8 @@ impl Processor {
                 stack.push(a % b);
             }
             InstructionSet::LOADLABEL => {},
-            InstructionSet::JMP(value) => {
-                self.pc = *value as usize;
+            InstructionSet::JMP(label) => {
+                self.pc = *label as usize;
             },
             InstructionSet::LOADREGISTER(register_idx) => {
                 if *register_idx < 0 || (*register_idx as usize) > self.registers.len() {
@@ -143,7 +143,18 @@ impl Processor {
                     Some(value) => value,
                     None => panic!("Stack is empty!"),
                 };
+            },
+            InstructionSet::JZ(label) => {
+                if self.flag_register.zero {
+                    self.pc = *label as usize;
+                }
             }
+        }
+
+        if stack.data().len() > 0 && *stack.top() == 0 {
+            self.flag_register.zero = true;
+        } else {
+            self.flag_register.zero = false;
         }
     }
 

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -34,6 +34,9 @@ fn test_instruction_equality() {
 
     let instruction = InstructionSet::POPREGISTER(2);
     assert_eq!(instruction, InstructionSet::POPREGISTER(2));
+
+    let instruction = InstructionSet::JZ(2);
+    assert_eq!(instruction, InstructionSet::JZ(2));
 }
 
 #[test]
@@ -70,4 +73,7 @@ fn test_instruction_from_int() {
 
     let instruction = InstructionSet::from_int(10, Some(2));
     assert_eq!(instruction, InstructionSet::POPREGISTER(2));
+
+    let instruction = InstructionSet::from_int(11, Some(2));
+    assert_eq!(instruction, InstructionSet::JZ(2));
 }

--- a/tests/test_memory.rs
+++ b/tests/test_memory.rs
@@ -23,6 +23,15 @@ fn test_stack_pop() {
 }
 
 #[test]
+fn test_stack_top() {
+    let mut stack = Stack::new();
+    stack.push(3);
+    stack.push(4);
+
+    assert_eq!(*stack.top(), 4);
+}
+
+#[test]
 fn test_memory_get_value() {
     let mut memory = Memory::new();
     memory.add_value(InstructionSet::LOAD(3));

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -148,6 +148,17 @@ fn test_execute_popregister() {
 }
 
 #[test]
+fn test_execute_jz() {
+    let mut stack = Stack::new();
+    let mut processor = Processor::new();
+
+    processor.execute(&InstructionSet::JZ(2), &mut stack, &mut Vec::new());
+
+    assert_eq!(stack.data(), &[]);
+    assert_eq!(stack.head(), 0);
+}
+
+#[test]
 fn test_execute_program() {
     let mut program = Vec::new();
 


### PR DESCRIPTION
Closes #15 

**Implementation**

1. Add JZ in the instruction set and identify it in binread.
2. In the processor after every instruction is executed check if the top of the stack is 0 or not (the result of the last instruction), if it is 0 then turn on the zero flag otherwise turn it off. 
3. To check the top value of the stack add a new method in `Stack` struct called `top()` which returns the top most value of the stack. 
4. To execute JZ jump to the index if zero flag is set, otherwise continue sequential execution. 