### PR TITLE
Add JN instruction

### DIFF
--- a/src/binread/bin_read.rs
+++ b/src/binread/bin_read.rs
@@ -30,6 +30,7 @@ pub fn read_from_file(filepath: &str) -> Vec<InstructionSet> {
         9, // LOADREGISTER
         10, // POPREGISTER
         11, // JZ
+        12, // JN
     ];
 
     let mut program = Vec::new();

--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -14,6 +14,7 @@ pub enum InstructionSet {
     LOADREGISTER(InnerData),
     POPREGISTER(InnerData),
     JZ(InnerData),
+    JN(InnerData),
 }
 
 impl PartialEq for InstructionSet {
@@ -31,6 +32,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::LOADREGISTER(a), InstructionSet::LOADREGISTER(b)) => a == b,
             (InstructionSet::POPREGISTER(a), InstructionSet::POPREGISTER(b)) => a == b,
             (InstructionSet::JZ(a), InstructionSet::JZ(b)) => a == b,
+            (InstructionSet::JN(a), InstructionSet::JN(b)) => a == b,
             _ => false,
         }
     }
@@ -74,6 +76,12 @@ impl InstructionSet {
                 match arg {
                     Some(arg) => InstructionSet::JZ(arg),
                     None => panic!("InstructionSet::JZ: arg is None"),
+                }
+            },
+            12 => {
+                match arg {
+                    Some(arg) => InstructionSet::JN(arg),
+                    None => panic!("InstructionSet::JN: arg is None"),
                 }
             },
             _ => panic!("Invalid instruction set value: {}", value),

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -148,13 +148,21 @@ impl Processor {
                 if self.flag_register.zero {
                     self.pc = *label as usize;
                 }
-            }
+            },
+            InstructionSet::JN(label) => {
+                if self.flag_register.negative {
+                    self.pc = *label as usize;
+                }
+            },
         }
 
         if stack.data().len() > 0 && *stack.top() == 0 {
             self.flag_register.zero = true;
+        } else if stack.data.len() > 0 && *stack.top() < 0 {
+            self.flag_register.negative = true;
         } else {
             self.flag_register.zero = false;
+            self.flag_register.negative = false;
         }
     }
 

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -37,6 +37,9 @@ fn test_instruction_equality() {
 
     let instruction = InstructionSet::JZ(2);
     assert_eq!(instruction, InstructionSet::JZ(2));
+
+    let instruction = InstructionSet::JN(2);
+    assert_eq!(instruction, InstructionSet::JN(2));
 }
 
 #[test]
@@ -76,4 +79,7 @@ fn test_instruction_from_int() {
 
     let instruction = InstructionSet::from_int(11, Some(2));
     assert_eq!(instruction, InstructionSet::JZ(2));
+
+    let instruction = InstructionSet::from_int(12, Some(2));
+    assert_eq!(instruction, InstructionSet::JN(2));
 }

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -159,6 +159,17 @@ fn test_execute_jz() {
 }
 
 #[test]
+fn test_execute_jn() {
+    let mut stack = Stack::new();
+    let mut processor = Processor::new();
+
+    processor.execute(&InstructionSet::JN(2), &mut stack, &mut Vec::new());
+
+    assert_eq!(stack.data(), &[]);
+    assert_eq!(stack.head(), 0);
+}
+
+#[test]
 fn test_execute_program() {
     let mut program = Vec::new();
 


### PR DESCRIPTION
Closes #16 

**Implementation**

1. Add JN in the instruction set and identify it in binread.
2. In the processor after every instruction is executed check if the top of the stack is negative or not (the result of the last instruction), if it is negative then turn on the negative flag otherwise turn it off. 
3. To execute JN jump to the index if negative flag is set, otherwise continues sequential execution. 