### PR TITLE
Add support for string

### DIFF
--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -95,6 +95,7 @@ impl InstructionSet {
                 }
             },
             12 => InstructionSet::STARTSTR,
+            13 => InstructionSet::ENDSTR,
             _ => panic!("Invalid instruction set value: {}", value),
         }
     }

--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -14,6 +14,8 @@ pub enum InstructionSet {
     POP(InnerData, u8),
     JZ(InnerData),
     JN(InnerData),
+    STARTSTR,
+    ENDSTR,
 }
 
 impl PartialEq for InstructionSet {
@@ -31,6 +33,8 @@ impl PartialEq for InstructionSet {
             (InstructionSet::POP(a, b), InstructionSet::POP(c, d)) => a == c && b == d,
             (InstructionSet::JZ(a), InstructionSet::JZ(b)) => a == b,
             (InstructionSet::JN(a), InstructionSet::JN(b)) => a == b,
+            (InstructionSet::STARTSTR, InstructionSet::STARTSTR) => true,
+            (InstructionSet::ENDSTR, InstructionSet::ENDSTR) => true,
             _ => false,
         }
     }
@@ -46,11 +50,11 @@ impl InstructionSet {
                 };
 
                 let second_arg = match arg1 {
-                    Some(arg) => arg,
+                    Some(arg) => arg.get_u8(),
                     None => panic!("InstructionSet::LOAD: arg1 is None"),
                 };
 
-                InstructionSet::LOAD(first_arg, second_arg as u8)
+                InstructionSet::LOAD(first_arg, second_arg)
             },
             1 => InstructionSet::ADD,
             2 => InstructionSet::SUB,
@@ -72,11 +76,11 @@ impl InstructionSet {
                 };
 
                 let second_arg = match arg1 {
-                    Some(arg) => arg,
+                    Some(arg) => arg.get_u8(),
                     None => panic!("InstructionSet::LOAD: arg1 is None"),
                 };
 
-                InstructionSet::POP(first_arg, second_arg as u8)
+                InstructionSet::POP(first_arg, second_arg)
             },
             10 => {
                 match arg {
@@ -90,6 +94,7 @@ impl InstructionSet {
                     None => panic!("InstructionSet::JN: arg is None"),
                 }
             },
+            12 => InstructionSet::STARTSTR,
             _ => panic!("Invalid instruction set value: {}", value),
         }
     }

--- a/src/memory/data.rs
+++ b/src/memory/data.rs
@@ -1,1 +1,120 @@
-pub type InnerData = i8;
+use std::ops::{Add, Sub, Mul, Div, Rem};
+use std::fmt::{Display, self};
+
+#[derive(Debug)]
+pub enum InnerData {
+    INT(i8),
+    STR(String),
+}
+
+impl PartialEq for InnerData {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (InnerData::INT(a), InnerData::INT(b)) => a == b,
+            (InnerData::STR(a), InnerData::STR(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl InnerData {
+    pub fn get_u8(&self) -> u8 {
+        match self {
+            InnerData::INT(a) => *a as u8,
+            InnerData::STR(_) => panic!("InnerData::get_u8: not implemented for STR"),
+        }
+    }
+
+    pub fn get_i8(&self) -> i8 {
+        match self {
+            InnerData::INT(a) => *a,
+            InnerData::STR(_) => panic!("InnerData::get_i8: not implemented for STR"),
+        }
+    }
+
+    pub fn clone(&self) -> InnerData {
+        match self {
+            InnerData::INT(a) => InnerData::INT(*a),
+            InnerData::STR(a) => InnerData::STR(a.clone()),
+        }
+    }
+}
+
+impl Add for InnerData {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        match (self, other) {
+            (InnerData::INT(a), InnerData::INT(b)) => InnerData::INT(a + b),
+            (InnerData::STR(a), InnerData::STR(b)) => InnerData::STR(a + &b),
+            _ => panic!("Illegal add operation"),
+        }
+    }
+}
+
+impl Sub for InnerData {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        match (self, other) {
+            (InnerData::INT(a), InnerData::INT(b)) => InnerData::INT(a - b),
+            _ => panic!("Illegal sub operation"),
+        }
+    }
+}
+
+impl Mul for InnerData {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        match (self, other) {
+            (InnerData::INT(a), InnerData::INT(b)) => InnerData::INT(a * b),
+            (InnerData::STR(a), InnerData::INT(b)) => {
+                let mut result = String::new();
+                for _ in 0..b {
+                    result.push_str(&a);
+                }
+                InnerData::STR(result)
+            },
+            (InnerData::INT(a), InnerData::STR(b)) => {
+                let mut result = String::new();
+                for _ in 0..a {
+                    result.push_str(&b);
+                }
+                InnerData::STR(result)
+            },
+            _ => panic!("Illegal mul operation"),
+        }
+    }
+}
+
+impl Div for InnerData {
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        match (self, other) {
+            (InnerData::INT(a), InnerData::INT(b)) => InnerData::INT(a / b),
+            _ => panic!("Illegal div operation"),
+        }
+    }
+}
+
+impl Rem for InnerData {
+    type Output = Self;
+
+    fn rem(self, other: Self) -> Self {
+        match (self, other) {
+            (InnerData::INT(a), InnerData::INT(b)) => InnerData::INT(a % b),
+            _ => panic!("Illegal rem operation"),
+        }
+    }
+}
+
+impl Display for InnerData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InnerData::INT(a) => write!(f, "{}", a),
+            InnerData::STR(a) => write!(f, "{}", a),
+        }
+    }
+}

--- a/tests/test_binread.rs
+++ b/tests/test_binread.rs
@@ -1,5 +1,6 @@
 use yamini::binread::read_from_file;
 use yamini::instructions::InstructionSet;
+use yamini::memory::InnerData;
 
 #[test]
 fn test_read_from_file() {
@@ -8,8 +9,8 @@ fn test_read_from_file() {
     assert_eq!(program.len(), 4);
 
     let expected_program = vec![
-        InstructionSet::LOAD(3, 200),
-        InstructionSet::LOAD(4, 200),
+        InstructionSet::LOAD(InnerData::INT(3), 200),
+        InstructionSet::LOAD(InnerData::INT(4), 200),
         InstructionSet::ADD,
         InstructionSet::RET,
     ];

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -1,9 +1,9 @@
-use yamini::instructions::InstructionSet;
+use yamini::{instructions::InstructionSet, memory::InnerData};
 
 #[test]
 fn test_instruction_equality() {
-    let instruction = InstructionSet::LOAD(3, 200);
-    assert_eq!(instruction, InstructionSet::LOAD(3, 200));
+    let instruction = InstructionSet::LOAD(InnerData::INT(3), 200);
+    assert_eq!(instruction, InstructionSet::LOAD(InnerData::INT(3), 200));
 
     let instruction = InstructionSet::ADD;
     assert_eq!(instruction, InstructionSet::ADD);
@@ -26,23 +26,29 @@ fn test_instruction_equality() {
     let instruction = InstructionSet::LABEL;
     assert_eq!(instruction, InstructionSet::LABEL);
 
-    let instruction = InstructionSet::JMP(3);
-    assert_eq!(instruction, InstructionSet::JMP(3));
+    let instruction = InstructionSet::JMP(InnerData::INT(3));
+    assert_eq!(instruction, InstructionSet::JMP(InnerData::INT(3)));
 
-    let instruction = InstructionSet::POP(2, 100);
-    assert_eq!(instruction, InstructionSet::POP(2, 100));
+    let instruction = InstructionSet::POP(InnerData::INT(2), 100);
+    assert_eq!(instruction, InstructionSet::POP(InnerData::INT(2), 100));
 
-    let instruction = InstructionSet::JZ(2);
-    assert_eq!(instruction, InstructionSet::JZ(2));
+    let instruction = InstructionSet::JZ(InnerData::INT(2));
+    assert_eq!(instruction, InstructionSet::JZ(InnerData::INT(2)));
 
-    let instruction = InstructionSet::JN(2);
-    assert_eq!(instruction, InstructionSet::JN(2));
+    let instruction = InstructionSet::JN(InnerData::INT(2));
+    assert_eq!(instruction, InstructionSet::JN(InnerData::INT(2)));
+
+    let instruction = InstructionSet::STARTSTR;
+    assert_eq!(instruction, InstructionSet::STARTSTR);
+
+    let instruction = InstructionSet::ENDSTR;
+    assert_eq!(instruction, InstructionSet::ENDSTR);
 }
 
 #[test]
 fn test_instruction_from_int() {
-    let instruction = InstructionSet::from_int(0, Some(2), Some(100));
-    assert_eq!(instruction, InstructionSet::LOAD(2, 100));
+    let instruction = InstructionSet::from_int(0, Some(InnerData::INT(2)), Some(InnerData::INT(100)));
+    assert_eq!(instruction, InstructionSet::LOAD(InnerData::INT(2), 100));
 
     let instruction = InstructionSet::from_int(1, None, None);
     assert_eq!(instruction, InstructionSet::ADD);
@@ -65,15 +71,21 @@ fn test_instruction_from_int() {
     let instruction = InstructionSet::from_int(7, None, None);
     assert_eq!(instruction, InstructionSet::LABEL);
 
-    let instruction = InstructionSet::from_int(8, Some(2), None);
-    assert_eq!(instruction, InstructionSet::JMP(2));
+    let instruction = InstructionSet::from_int(8, Some(InnerData::INT(2)), None);
+    assert_eq!(instruction, InstructionSet::JMP(InnerData::INT(2)));
 
-    let instruction = InstructionSet::from_int(9, Some(2), Some(100));
-    assert_eq!(instruction, InstructionSet::POP(2, 100));
+    let instruction = InstructionSet::from_int(9, Some(InnerData::INT(2)), Some(InnerData::INT(100)));
+    assert_eq!(instruction, InstructionSet::POP(InnerData::INT(2), 100));
 
-    let instruction = InstructionSet::from_int(10, Some(2), None);
-    assert_eq!(instruction, InstructionSet::JZ(2));
+    let instruction = InstructionSet::from_int(10, Some(InnerData::INT(2)), None);
+    assert_eq!(instruction, InstructionSet::JZ(InnerData::INT(2)));
 
-    let instruction = InstructionSet::from_int(11, Some(2), None);
-    assert_eq!(instruction, InstructionSet::JN(2));
+    let instruction = InstructionSet::from_int(11, Some(InnerData::INT(2)), None);
+    assert_eq!(instruction, InstructionSet::JN(InnerData::INT(2)));
+
+    let instruction = InstructionSet::from_int(12, None, None);
+    assert_eq!(instruction, InstructionSet::STARTSTR);
+
+    let instruction = InstructionSet::from_int(13, None, None);
+    assert_eq!(instruction, InstructionSet::ENDSTR);
 }

--- a/tests/test_memory.rs
+++ b/tests/test_memory.rs
@@ -1,63 +1,63 @@
-use yamini::memory::{Stack, Memory};
+use yamini::memory::{Stack, Memory, InnerData};
 use yamini::instructions::InstructionSet;
 
 #[test]
 fn test_stack_push() {
     let mut stack = Stack::new();
-    stack.push(3);
-    stack.push(4);
+    stack.push(InnerData::INT(3));
+    stack.push(InnerData::INT(4));
 
-    assert_eq!(stack.data(), &[3, 4]);
+    assert_eq!(stack.data(), &[InnerData::INT(3), InnerData::INT(4)]);
     assert_eq!(stack.head(), 2);
 }
 
 #[test]
 fn test_stack_pop() {
     let mut stack = Stack::new();
-    stack.push(3);
-    stack.push(4);
+    stack.push(InnerData::INT(3));
+    stack.push(InnerData::INT(4));
 
-    assert_eq!(stack.pop(), Some(4));
-    assert_eq!(stack.pop(), Some(3));
+    assert_eq!(stack.pop(), Some(InnerData::INT(4)));
+    assert_eq!(stack.pop(), Some(InnerData::INT(3)));
     assert_eq!(stack.pop(), None);
 }
 
 #[test]
 fn test_stack_top() {
     let mut stack = Stack::new();
-    stack.push(3);
-    stack.push(4);
+    stack.push(InnerData::INT(3));
+    stack.push(InnerData::INT(4));
 
-    assert_eq!(*stack.top(), 4);
+    assert_eq!(*stack.top(), InnerData::INT(4));
 }
 
 #[test]
 fn test_memory_get_value() {
     let mut memory = Memory::new();
-    memory.add_value(InstructionSet::LOAD(3, 100));
+    memory.add_value(InstructionSet::LOAD(InnerData::INT(3), 100));
 
     let instruction = memory.get_value(0);
 
-    assert_eq!(*instruction, InstructionSet::LOAD(3, 100));
+    assert_eq!(*instruction, InstructionSet::LOAD(InnerData::INT(3), 100));
 }
 
 #[test]
 fn test_memory_set_value() {
     let mut memory = Memory::new();
-    memory.add_value(InstructionSet::LOAD(3, 100));
+    memory.add_value(InstructionSet::LOAD(InnerData::INT(3), 100));
 
-    memory.set_value(0, InstructionSet::LOAD(4, 100));
+    memory.set_value(0, InstructionSet::LOAD(InnerData::INT(4), 100));
 
     let instruction = memory.get_value(0);
 
-    assert_eq!(*instruction, InstructionSet::LOAD(4, 100));
+    assert_eq!(*instruction, InstructionSet::LOAD(InnerData::INT(4), 100));
 }
 
 #[test]
 fn test_memory_add_value() {
     let mut memory = Memory::new();
 
-    let idx = memory.add_value(InstructionSet::LOAD(3, 100));
+    let idx = memory.add_value(InstructionSet::LOAD(InnerData::INT(3), 100));
 
     assert_eq!(idx, 0);
 }
@@ -67,10 +67,10 @@ fn test_memory_load_program() {
     let mut memory = Memory::new();
     let mut program = Vec::new();
 
-    program.push(InstructionSet::LOAD(3, 100));
-    program.push(InstructionSet::LOAD(4, 100));
+    program.push(InstructionSet::LOAD(InnerData::INT(3), 100));
+    program.push(InstructionSet::LOAD(InnerData::INT(4), 100));
 
     memory.load_program(program);
 
-    assert_eq!(memory.data(), vec![InstructionSet::LOAD(3, 100), InstructionSet::LOAD(4, 100)].as_slice());
+    assert_eq!(memory.data(), vec![InstructionSet::LOAD(InnerData::INT(3), 100), InstructionSet::LOAD(InnerData::INT(4), 100)].as_slice());
 }

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -1,5 +1,5 @@
 use yamini::processor::Processor;
-use yamini::memory::{Stack, Memory};
+use yamini::memory::{Stack, Memory, InnerData};
 use yamini::instructions::InstructionSet;
 
 
@@ -9,72 +9,72 @@ fn test_execute_load() {
 
     let mut processor = Processor::new();
 
-    processor.execute(&InstructionSet::LOAD(3, 200), &mut stack, &mut Vec::new());
+    processor.execute(&InstructionSet::LOAD(InnerData::INT(3), 200), &mut stack, &mut Vec::new());
 
-    assert_eq!(stack.data(), &[3]);
+    assert_eq!(stack.data(), &[InnerData::INT(3)]);
     assert_eq!(stack.head(), 1);
 }
 
 #[test]
 fn test_execute_add() {
     let mut stack = Stack::new();
-    stack.push(3);
-    stack.push(4);
+    stack.push(InnerData::INT(3));
+    stack.push(InnerData::INT(4));
 
     let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::ADD, &mut stack, &mut Vec::new());
 
-    assert_eq!(stack.data(), &[7]);
+    assert_eq!(stack.data(), &[InnerData::INT(7)]);
     assert_eq!(stack.head(), 1);
 }
 
 #[test]
 fn test_execute_sub() {
     let mut stack = Stack::new();
-    stack.push(3);
-    stack.push(4);
+    stack.push(InnerData::INT(3));
+    stack.push(InnerData::INT(4));
 
     let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::SUB, &mut stack, &mut Vec::new());
 
-    assert_eq!(stack.data(), &[-1]);
+    assert_eq!(stack.data(), &[InnerData::INT(-1)]);
     assert_eq!(stack.head(), 1);
 }
 
 #[test]
 fn test_execute_mul() {
     let mut stack = Stack::new();
-    stack.push(3);
-    stack.push(4);
+    stack.push(InnerData::INT(3));
+    stack.push(InnerData::INT(4));
 
     let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::MUL, &mut stack, &mut Vec::new());
 
-    assert_eq!(stack.data(), &[12]);
+    assert_eq!(stack.data(), &[InnerData::INT(12)]);
     assert_eq!(stack.head(), 1);
 }
 
 #[test]
 fn test_execute_div() {
     let mut stack = Stack::new();
-    stack.push(12);
-    stack.push(4);
+    stack.push(InnerData::INT(12));
+    stack.push(InnerData::INT(4));
 
     let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::DIV, &mut stack, &mut Vec::new());
 
-    assert_eq!(stack.data(), &[3]);
+    assert_eq!(stack.data(), &[InnerData::INT(3)]);
     assert_eq!(stack.head(), 1);
 }
 
 #[test]
 fn test_execute_ret() {
     let mut stack = Stack::new();
-    stack.push(3);
+    stack.push(InnerData::INT(3));
 
     let mut processor = Processor::new();
 
@@ -91,14 +91,14 @@ fn test_execute_ret() {
 #[test]
 fn test_execute_mod() {
     let mut stack = Stack::new();
-    stack.push(12);
-    stack.push(5);
+    stack.push(InnerData::INT(12));
+    stack.push(InnerData::INT(5));
 
     let mut processor = Processor::new();
 
     processor.execute(&InstructionSet::DIV, &mut stack, &mut Vec::new());
 
-    assert_eq!(stack.data(), &[2]);
+    assert_eq!(stack.data(), &[InnerData::INT(2)]);
     assert_eq!(stack.head(), 1);
 }
 
@@ -118,7 +118,7 @@ fn test_execute_jmp() {
     let mut stack = Stack::new();
     let mut processor = Processor::new();
 
-    processor.execute(&InstructionSet::JMP(2), &mut stack, &mut Vec::new());
+    processor.execute(&InstructionSet::JMP(InnerData::INT(2)), &mut stack, &mut Vec::new());
 
     assert_eq!(stack.data(), &[]);
     assert_eq!(stack.head(), 0);
@@ -129,8 +129,8 @@ fn test_execute_popregister() {
     let mut stack = Stack::new();
     let mut processor = Processor::new();
 
-    processor.execute(&InstructionSet::LOAD(2, 100), &mut stack, &mut Vec::new());
-    processor.execute(&InstructionSet::POP(2, 100), &mut stack, &mut Vec::new());
+    processor.execute(&InstructionSet::LOAD(InnerData::INT(2), 100), &mut stack, &mut Vec::new());
+    processor.execute(&InstructionSet::POP(InnerData::INT(2), 100), &mut stack, &mut Vec::new());
 
     assert_eq!(stack.data(), &[]);
     assert_eq!(stack.head(), 0);
@@ -141,7 +141,7 @@ fn test_execute_jz() {
     let mut stack = Stack::new();
     let mut processor = Processor::new();
 
-    processor.execute(&InstructionSet::JZ(2), &mut stack, &mut Vec::new());
+    processor.execute(&InstructionSet::JZ(InnerData::INT(2)), &mut stack, &mut Vec::new());
 
     assert_eq!(stack.data(), &[]);
     assert_eq!(stack.head(), 0);
@@ -152,7 +152,7 @@ fn test_execute_jn() {
     let mut stack = Stack::new();
     let mut processor = Processor::new();
 
-    processor.execute(&InstructionSet::JN(2), &mut stack, &mut Vec::new());
+    processor.execute(&InstructionSet::JN(InnerData::INT(2)), &mut stack, &mut Vec::new());
 
     assert_eq!(stack.data(), &[]);
     assert_eq!(stack.head(), 0);
@@ -162,8 +162,8 @@ fn test_execute_jn() {
 fn test_execute_program() {
     let mut program = Vec::new();
 
-    program.push(InstructionSet::LOAD(3, 200));
-    program.push(InstructionSet::LOAD(4, 200));
+    program.push(InstructionSet::LOAD(InnerData::INT(3), 200));
+    program.push(InstructionSet::LOAD(InnerData::INT(4), 200));
     program.push(InstructionSet::MUL);
     program.push(InstructionSet::RET);
 


### PR DESCRIPTION
Closes #19 

**Implementation**

1. Modify binread and add a new state called ReadObject that reads a string using `STARTSTR` and `ENDSTR` marker instructions. Convert the ASCII characters into a string while building the instructions.
2. Marker instructions are instructions that do not execute but are there for marking the start and end of some object of unknown size.
3. Modify the InnerData to be an enum instead of a type alias to i8, it now stores two varieties of data INT or STRING. Make changes in all modules for the same.
4. The processor remains same, apart from changes from InnerData structure changes. 