### PR TITLE
EQU implementation

### DIFF
--- a/src/binread/bin_read.rs
+++ b/src/binread/bin_read.rs
@@ -41,8 +41,9 @@ pub fn read_from_file(filepath: &str) -> Vec<InstructionSet> {
     ];
 
     let instruction_with_two_args = vec![
-        0, // LOAD
-        9, // POP
+        0,  // LOAD
+        9,  // POP
+        17, // EQU
     ];
 
     let mut object_instructions_with_end = HashMap::new();

--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -19,6 +19,7 @@ pub enum InstructionSet {
     SHOW,
     RET,
     CALL(InnerData),
+    EQU(InnerData, u8),
 }
 
 impl PartialEq for InstructionSet {
@@ -41,6 +42,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::SHOW, InstructionSet::SHOW) => true,
             (InstructionSet::RET, InstructionSet::RET) => true,
             (InstructionSet::CALL(a), InstructionSet::CALL(b)) => a == b,
+            (InstructionSet::EQU(a, b), InstructionSet::EQU(c, d)) => a == c && b == d,
             _ => false,
         }
     }
@@ -109,6 +111,19 @@ impl InstructionSet {
                     Some(arg) => InstructionSet::CALL(arg),
                     None => panic!("InstructionSet::CALL: arg is None"),
                 }
+            },
+            17 => {
+                let first_arg = match arg {
+                    Some(arg) => arg,
+                    None => panic!("InstructionSet::EQU: arg is None"),
+                };
+
+                let second_arg = match arg1 {
+                    Some(arg) => arg.get_u8(),
+                    None => panic!("InstructionSet::EQU: arg1 is None"),
+                };
+
+                InstructionSet::EQU(first_arg, second_arg)
             },
             _ => panic!("Invalid instruction set value: {}", value),
         }

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -170,6 +170,40 @@ impl Processor {
                 call_stack.push(InnerData::INT(self.pc as i8));
                 self.pc = label.get_u8() as usize;
             },
+            InstructionSet::EQU(value, offset) => {
+                let stack_top_val = match stack.pop() {
+                    Some(value) => value,
+                    None => panic!("Stack is empty!"),
+                };
+                
+                let stack_top_val_clone = stack_top_val.clone();
+                stack.push(stack_top_val_clone);
+
+                if offset == &REGISTER_OFFSET {
+                    if value.get_i8() < 0 || value.get_i8() as usize > self.registers.len() {
+                        panic!("Register index out of bounds!");
+                    }
+
+                    let register_val = self.registers[value.get_u8() as usize];
+
+                    match (stack_top_val, register_val) {
+                        (InnerData::INT(a), b) => {
+                            stack.push(InnerData::INT(if a == b { 1 } else { 0 }));
+                        },
+                        _ => stack.push(InnerData::INT(0)),
+                    }
+                } else if offset == &STACK_OFFSET {
+                    match (stack_top_val, value) {
+                        (InnerData::INT(stack_top_val), InnerData::INT(value)) => {
+                            stack.push(InnerData::INT(if stack_top_val == *value { 1 } else { 0 }));
+                        },
+                        (InnerData::STR(stack_top_val), InnerData::STR(value)) => {
+                            stack.push(InnerData::INT(if stack_top_val == *value { 1 } else { 0 }));
+                        },
+                        _ => stack.push(InnerData::INT(0))
+                    }
+                }
+            }
         }
 
         if stack.data.len() > 0 {

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -52,6 +52,9 @@ fn test_instruction_equality() {
 
     let instruction = InstructionSet::CALL(InnerData::INT(2));
     assert_eq!(instruction, InstructionSet::CALL(InnerData::INT(2)));
+
+    let instruction = InstructionSet::EQU(InnerData::INT(2), 100);
+    assert_eq!(instruction, InstructionSet::EQU(InnerData::INT(2), 100));
 }
 
 #[test]
@@ -106,4 +109,7 @@ fn test_instruction_from_int() {
 
     let instruction = InstructionSet::from_int(16, Some(InnerData::INT(2)), None);
     assert_eq!(instruction, InstructionSet::CALL(InnerData::INT(2)));
+
+    let instruction = InstructionSet::from_int(17, Some(InnerData::INT(2)), Some(InnerData::INT(100)));
+    assert_eq!(instruction, InstructionSet::EQU(InnerData::INT(2), 100));
 }

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -209,6 +209,20 @@ fn test_execute_call() {
 }
 
 #[test]
+fn test_execute_equ() {
+    let mut stack = Stack::new();
+    stack.push(InnerData::INT(3));
+
+    let mut processor = Processor::new();
+
+    processor.execute(&InstructionSet::EQU(InnerData::INT(3), 200), &mut stack, 
+                      &mut Stack::new(), &mut Vec::new());
+
+    assert_eq!(stack.data(), &[InnerData::INT(3), InnerData::INT(1)]);
+    assert_eq!(stack.head(), 2);
+}
+
+#[test]
 fn test_execute_program() {
     let mut program = Vec::new();
 


### PR DESCRIPTION
Closes #30 

**Implementation**

1. Add `EQU` instruction in the instruction set and identify it as instruction with two arguments in binread.
2. During processing check if the value to compare is in the stack or in one of the registers based on the offset and then match on the type of both the stack top and the value provided as well as match on the actual values only if both are equal can the equality result in a true value of 1, in all other cases it results in a value of false or 0.