### PR TITLE
Add implementation of NEG

### DIFF
--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -20,6 +20,7 @@ pub enum InstructionSet {
     RET,
     CALL(InnerData),
     EQU(InnerData, u8),
+    NEG,
 }
 
 impl PartialEq for InstructionSet {
@@ -43,6 +44,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::RET, InstructionSet::RET) => true,
             (InstructionSet::CALL(a), InstructionSet::CALL(b)) => a == b,
             (InstructionSet::EQU(a, b), InstructionSet::EQU(c, d)) => a == c && b == d,
+            (InstructionSet::NEG, InstructionSet::NEG) => true,
             _ => false,
         }
     }
@@ -125,6 +127,7 @@ impl InstructionSet {
 
                 InstructionSet::EQU(first_arg, second_arg)
             },
+            18 => InstructionSet::NEG,
             _ => panic!("Invalid instruction set value: {}", value),
         }
     }

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -217,6 +217,17 @@ impl Processor {
                         _ => stack.push(InnerData::INT(0))
                     }
                 }
+            },
+            InstructionSet::NEG => {
+                let value = match stack.pop() {
+                    Some(value) => value,
+                    None => panic!("Stack is empty!"),
+                };
+
+                match value {
+                    InnerData::INT(value) => stack.push(InnerData::INT(-value)),
+                    _ => panic!("Invalid type!"),
+                }
             }
         }
 

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -55,6 +55,9 @@ fn test_instruction_equality() {
 
     let instruction = InstructionSet::EQU(InnerData::INT(2), 100);
     assert_eq!(instruction, InstructionSet::EQU(InnerData::INT(2), 100));
+
+    let instruction = InstructionSet::NEG;
+    assert_eq!(instruction, InstructionSet::NEG);
 }
 
 #[test]
@@ -112,4 +115,7 @@ fn test_instruction_from_int() {
 
     let instruction = InstructionSet::from_int(17, Some(InnerData::INT(2)), Some(InnerData::INT(100)));
     assert_eq!(instruction, InstructionSet::EQU(InnerData::INT(2), 100));
+
+    let instruction = InstructionSet::from_int(18, None, None);
+    assert_eq!(instruction, InstructionSet::NEG);
 }

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -177,6 +177,25 @@ fn test_execute_jmp() {
 }
 
 #[test]
+fn test_execute_neg() {
+    let mut stack = Stack::new();
+    stack.push(InnerData::INT(3));
+
+    let mut processor = Processor::new();
+
+    processor.execute(
+        &InstructionSet::NEG,
+        &mut DataMemory::new(),
+        &mut stack, 
+        &mut Stack::new(), 
+        &mut Vec::new()
+    );
+
+    assert_eq!(stack.data(), &[InnerData::INT(-3)]);
+    assert_eq!(stack.head(), 1);
+}
+
+#[test]
 fn test_execute_popregister() {
     let mut stack = Stack::new();
     let mut processor = Processor::new();


### PR DESCRIPTION
Closes #36 

**Implementation**

1. Add `NEG` as instruction in the instruction set.
2. In the processor, pop a single value from the stack, if it is an integer value then negate it and push it back to the stack. 