### PR TITLE
Fix implementation of EQU, make it similar to bin ops

### DIFF
--- a/src/binread/bin_read.rs
+++ b/src/binread/bin_read.rs
@@ -43,7 +43,6 @@ pub fn read_from_file(filepath: &str) -> Vec<InstructionSet> {
     let instruction_with_two_args = vec![
         0,  // LOAD
         9,  // POP
-        17, // EQU
     ];
 
     let mut object_instructions_with_end = HashMap::new();

--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -19,7 +19,7 @@ pub enum InstructionSet {
     SHOW,
     RET,
     CALL(InnerData),
-    EQU(InnerData, u8),
+    EQU,
     NEG,
 }
 
@@ -43,7 +43,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::SHOW, InstructionSet::SHOW) => true,
             (InstructionSet::RET, InstructionSet::RET) => true,
             (InstructionSet::CALL(a), InstructionSet::CALL(b)) => a == b,
-            (InstructionSet::EQU(a, b), InstructionSet::EQU(c, d)) => a == c && b == d,
+            (InstructionSet::EQU, InstructionSet::EQU) => true,
             (InstructionSet::NEG, InstructionSet::NEG) => true,
             _ => false,
         }
@@ -114,19 +114,7 @@ impl InstructionSet {
                     None => panic!("InstructionSet::CALL: arg is None"),
                 }
             },
-            17 => {
-                let first_arg = match arg {
-                    Some(arg) => arg,
-                    None => panic!("InstructionSet::EQU: arg is None"),
-                };
-
-                let second_arg = match arg1 {
-                    Some(arg) => arg.get_u8(),
-                    None => panic!("InstructionSet::EQU: arg1 is None"),
-                };
-
-                InstructionSet::EQU(first_arg, second_arg)
-            },
+            17 => InstructionSet::EQU,
             18 => InstructionSet::NEG,
             _ => panic!("Invalid instruction set value: {}", value),
         }

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -184,37 +184,25 @@ impl Processor {
                 call_stack.push(InnerData::INT(self.pc as i8));
                 self.pc = label.get_u8() as usize;
             },
-            InstructionSet::EQU(value, offset) => {
-                let stack_top_val = match stack.pop() {
+            InstructionSet::EQU => {
+                let b = match stack.pop() {
                     Some(value) => value,
                     None => panic!("Stack is empty!"),
                 };
-                
-                let stack_top_val_clone = stack_top_val.clone();
-                stack.push(stack_top_val_clone);
+                let a = match stack.pop() {
+                    Some(value) => value,
+                    None => panic!("Stack is empty!"),
+                };
 
-                if offset == &REGISTER_OFFSET {
-                    if value.get_i8() < 0 || value.get_i8() as usize > self.registers.len() {
-                        panic!("Register index out of bounds!");
-                    }
-
-                    let register_val = self.registers[value.get_u8() as usize];
-
-                    match (stack_top_val, register_val) {
-                        (InnerData::INT(a), b) => {
-                            stack.push(InnerData::INT(if a == b { 1 } else { 0 }));
-                        },
-                        _ => stack.push(InnerData::INT(0)),
-                    }
-                } else if offset == &STACK_OFFSET || offset == &STACK_OFFSET_STR {
-                    match (stack_top_val, value) {
-                        (InnerData::INT(stack_top_val), InnerData::INT(value)) => {
-                            stack.push(InnerData::INT(if stack_top_val == *value { 1 } else { 0 }));
-                        },
-                        (InnerData::STR(stack_top_val), InnerData::STR(value)) => {
-                            stack.push(InnerData::INT(if stack_top_val == *value { 1 } else { 0 }));
-                        },
-                        _ => stack.push(InnerData::INT(0))
+                match (a, b) {
+                    (InnerData::INT(a), InnerData::INT(b)) => {
+                        stack.push(InnerData::INT(if a == b { 1 } else { 0 }));
+                    },
+                    (InnerData::STR(a), InnerData::STR(b)) => {
+                        stack.push(InnerData::INT(if a == b { 1 } else { 0 }));
+                    },
+                    _ => {
+                        stack.push(InnerData::INT(0));
                     }
                 }
             },

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -53,8 +53,8 @@ fn test_instruction_equality() {
     let instruction = InstructionSet::CALL(InnerData::INT(2));
     assert_eq!(instruction, InstructionSet::CALL(InnerData::INT(2)));
 
-    let instruction = InstructionSet::EQU(InnerData::INT(2), 100);
-    assert_eq!(instruction, InstructionSet::EQU(InnerData::INT(2), 100));
+    let instruction = InstructionSet::EQU;
+    assert_eq!(instruction, InstructionSet::EQU);
 
     let instruction = InstructionSet::NEG;
     assert_eq!(instruction, InstructionSet::NEG);
@@ -113,8 +113,8 @@ fn test_instruction_from_int() {
     let instruction = InstructionSet::from_int(16, Some(InnerData::INT(2)), None);
     assert_eq!(instruction, InstructionSet::CALL(InnerData::INT(2)));
 
-    let instruction = InstructionSet::from_int(17, Some(InnerData::INT(2)), Some(InnerData::INT(100)));
-    assert_eq!(instruction, InstructionSet::EQU(InnerData::INT(2), 100));
+    let instruction = InstructionSet::from_int(17, None, None);
+    assert_eq!(instruction, InstructionSet::EQU);
 
     let instruction = InstructionSet::from_int(18, None, None);
     assert_eq!(instruction, InstructionSet::NEG);

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -321,19 +321,20 @@ fn test_execute_call() {
 fn test_execute_equ() {
     let mut stack = Stack::new();
     stack.push(InnerData::INT(3));
+    stack.push(InnerData::INT(3));
 
     let mut processor = Processor::new();
 
     processor.execute(
-        &InstructionSet::EQU(InnerData::INT(3), 2),
+        &InstructionSet::EQU,
         &mut DataMemory::new(),
         &mut stack, 
         &mut Stack::new(), 
         &mut Vec::new()
     );
 
-    assert_eq!(stack.data(), &[InnerData::INT(3), InnerData::INT(1)]);
-    assert_eq!(stack.head(), 2);
+    assert_eq!(stack.data(), &[InnerData::INT(1)]);
+    assert_eq!(stack.head(), 1);
 }
 
 #[test]


### PR DESCRIPTION
Closes #38 

**Implementation**

1. Make it an op without arg in binread and instruction set.
2. During execution pop two values and match them.