### PR TITLE
Add variable address implementation

### DIFF
--- a/src/processor/constants.rs
+++ b/src/processor/constants.rs
@@ -3,3 +3,4 @@ pub(super) const STACK_OFFSET: u8 = 2;
 pub(super) const STACK_OFFSET_STR: u8 = 3;
 pub(super) const DATA_MEMORY_OFFSET: u8 = 4;
 pub(super) const DATA_MEMORY_OFFSET_STR: u8 = 5;
+pub(super) const ADDR_OFFSET: u8 = 6;

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -3,7 +3,8 @@ use crate::instructions::InstructionSet;
 use crate::memory::stack::Stack;
 use crate::memory::{ProgramMemory, DataMemory, InnerData};
 
-use super::constants::{REGISTER_OFFSET, STACK_OFFSET, STACK_OFFSET_STR, DATA_MEMORY_OFFSET, DATA_MEMORY_OFFSET_STR};
+use super::constants::{REGISTER_OFFSET, STACK_OFFSET, STACK_OFFSET_STR, DATA_MEMORY_OFFSET};
+use super::constants::{DATA_MEMORY_OFFSET_STR, ADDR_OFFSET};
 
 
 #[allow(dead_code)]
@@ -65,6 +66,8 @@ impl Processor {
                     stack.push(value.clone());
                 } else if offset == &DATA_MEMORY_OFFSET || offset == &DATA_MEMORY_OFFSET_STR {
                     stack.push(data_memory.get_var_value(value.get_u8()).clone());
+                } else if offset == &ADDR_OFFSET {
+                    stack.push(InnerData::INT(value.get_u8() as i8 * 8));
                 } else {
                     panic!("Invalid offset!");
                 }


### PR DESCRIPTION
Closes #40 

**Implementation**

1. Check if the offset is `ADDR_OFFSET` (= 6), if it is then execute the address loading of the variable.
2. Since the assembler index is actually used in the memory, it can directly be used while pushing to stack, it is just multiplied by 8 to show that it is an integer, which will help in language implementations. 