### PR TITLE
Add implementation of deref

### DIFF
--- a/src/instructions/instruction_set.rs
+++ b/src/instructions/instruction_set.rs
@@ -21,6 +21,7 @@ pub enum InstructionSet {
     CALL(InnerData),
     EQU,
     NEG,
+    DEREF,
 }
 
 impl PartialEq for InstructionSet {
@@ -45,6 +46,7 @@ impl PartialEq for InstructionSet {
             (InstructionSet::CALL(a), InstructionSet::CALL(b)) => a == b,
             (InstructionSet::EQU, InstructionSet::EQU) => true,
             (InstructionSet::NEG, InstructionSet::NEG) => true,
+            (InstructionSet::DEREF, InstructionSet::DEREF) => true,
             _ => false,
         }
     }
@@ -116,6 +118,7 @@ impl InstructionSet {
             },
             17 => InstructionSet::EQU,
             18 => InstructionSet::NEG,
+            19 => InstructionSet::DEREF,
             _ => panic!("Invalid instruction set value: {}", value),
         }
     }

--- a/src/processor/processor.rs
+++ b/src/processor/processor.rs
@@ -219,7 +219,20 @@ impl Processor {
                     InnerData::INT(value) => stack.push(InnerData::INT(-value)),
                     _ => panic!("Invalid type!"),
                 }
-            }
+            },
+            InstructionSet::DEREF => {
+                let value = match stack.pop() {
+                    Some(value) => value,
+                    None => panic!("Stack is empty!"),
+                };
+
+                match value {
+                    InnerData::INT(value) => stack.push(
+                        InnerData::INT(data_memory.get_var_value(value as u8 / 8).get_i8())
+                    ),
+                    _ => panic!("Invalid type!"),
+                }
+            },
         }
 
         if stack.data.len() > 0 {

--- a/tests/test_instructions.rs
+++ b/tests/test_instructions.rs
@@ -58,6 +58,9 @@ fn test_instruction_equality() {
 
     let instruction = InstructionSet::NEG;
     assert_eq!(instruction, InstructionSet::NEG);
+
+    let instruction = InstructionSet::DEREF;
+    assert_eq!(instruction, InstructionSet::DEREF);
 }
 
 #[test]
@@ -118,4 +121,7 @@ fn test_instruction_from_int() {
 
     let instruction = InstructionSet::from_int(18, None, None);
     assert_eq!(instruction, InstructionSet::NEG);
+
+    let instruction = InstructionSet::from_int(19, None, None);
+    assert_eq!(instruction, InstructionSet::DEREF);
 }

--- a/tests/test_processor.rs
+++ b/tests/test_processor.rs
@@ -338,6 +338,25 @@ fn test_execute_equ() {
 }
 
 #[test]
+fn test_execute_deref() {
+    let mut stack = Stack::new();
+    stack.push(InnerData::INT(3));
+
+    let mut processor = Processor::new();
+
+    processor.execute(
+        &InstructionSet::DEREF,
+        &mut DataMemory::new(),
+        &mut stack, 
+        &mut Stack::new(), 
+        &mut Vec::new()
+    );
+
+    assert_eq!(stack.data(), &[InnerData::INT(0)]);
+    assert_eq!(stack.head(), 1);
+}
+
+#[test]
 fn test_execute_program() {
     let mut program = Vec::new();
 


### PR DESCRIPTION
Closes #41 

**Implementation**

1. Add `LOAD` instruction in the instruction set.
2. During execution, pull out the value and divide it by 8 to get the original index and then get the value from data memory.