### PR TITLE
Use sargparse, add debug flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+sargparse = "~0.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
+extern crate sargparse;
+
 use std::io;
-use std::env;
+use sargparse::{ArgumentParser, ArgumentType, InnerData};
 
 use yamini::memory::DataMemory;
 use yamini::memory::Stack;
@@ -8,15 +10,29 @@ use yamini::processor::Processor;
 use yamini::binread::read_from_file;
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
-        println!("Usage: {} <filepath>", args[0]);
-        return;
-    }
+    let mut parser = ArgumentParser::new(Some("YamASM - Assembler for YaminiVM"));
 
-    let filepath = &args[1];
+    parser.add_argument("f", "file_path", "File path to executable binary", 
+                        true, None, ArgumentType::STR);
+    parser.add_argument("-i", "--instructions", "Flag to print compiled instructions",
+                        false, Some(InnerData::BOOL(false)), ArgumentType::BOOL);
+
+    let args = parser.parse_args().unwrap();
+
+    let filepath = &args.get("file_path").unwrap().get_str();
+    
+    let instructions_flag = args.get("instructions").unwrap().get_bool();
 
     let program = read_from_file(filepath);
+
+    if instructions_flag {
+        println!("--------------------------------------------");
+        println!("Instructions:");
+        for instruction in &program {
+            println!("{:?}", instruction);
+        }
+        println!("--------------------------------------------");
+    }
 
     let mut stack = Stack::new();
     let mut call_stack = Stack::new();


### PR DESCRIPTION
Closes #47

**Implementation**

1. Move from command line args parsing to using <a href="https://github.com/frankhart2018/sargparse.git">sargparse</a>.
2. Add debug flag - `--instructions`  for printing the instructions read from executable binary.